### PR TITLE
fix(bark): use markdown param instead of body for content rendering

### DIFF
--- a/packages/statocysts/src/services/push/bark/index.spec.ts
+++ b/packages/statocysts/src/services/push/bark/index.spec.ts
@@ -30,7 +30,7 @@ describe('bark basic functionality', () => {
     expect(req.headers.get('Content-Type')).toBe('application/json')
     expect(await req.json()).toEqual(expect.objectContaining({
       device_keys: ['myDeviceKey'],
-      body: 'Hello, world!',
+      markdown: 'Hello, world!',
     }))
   })
 
@@ -51,7 +51,7 @@ describe('bark basic functionality', () => {
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
       title: 'Test Title',
-      body: 'This is the message body',
+      markdown: 'This is the message body',
     })
   })
 
@@ -69,7 +69,7 @@ describe('bark basic functionality', () => {
     expect(req.url).toBe('https://bark.example.com/push')
     expect(await req.json()).toEqual({
       device_keys: ['deviceKey123'],
-      body: 'Custom Server',
+      markdown: 'Custom Server',
     })
   })
 
@@ -107,7 +107,7 @@ describe('bark query parameters', () => {
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
       title: 'Title',
-      body: 'Body',
+      markdown: 'Body',
       subtitle: 'Test Subtitle',
     })
   })
@@ -125,7 +125,7 @@ describe('bark query parameters', () => {
     const req = callArgs.request
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
-      body: 'Grouped notification',
+      markdown: 'Grouped notification',
       group: 'MyGroup',
     })
   })
@@ -143,7 +143,7 @@ describe('bark query parameters', () => {
     const req = callArgs.request
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
-      body: 'Click to open',
+      markdown: 'Click to open',
       url: 'https://example.com',
     })
   })
@@ -161,7 +161,7 @@ describe('bark query parameters', () => {
     const req = callArgs.request
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
-      body: 'Custom icon',
+      markdown: 'Custom icon',
       icon: 'https://example.com/icon.png',
     })
   })
@@ -179,7 +179,7 @@ describe('bark query parameters', () => {
     const req = callArgs.request
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
-      body: 'Alert!',
+      markdown: 'Alert!',
       sound: 'alarm',
     })
   })
@@ -197,7 +197,7 @@ describe('bark query parameters', () => {
     const req = callArgs.request
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
-      body: 'Continuous ringtone',
+      markdown: 'Continuous ringtone',
       call: '1',
     })
   })
@@ -215,7 +215,7 @@ describe('bark query parameters', () => {
     const req = callArgs.request
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
-      body: 'Active notification',
+      markdown: 'Active notification',
       level: 'active',
     })
   })
@@ -233,7 +233,7 @@ describe('bark query parameters', () => {
     const req = callArgs.request
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
-      body: 'Time sensitive',
+      markdown: 'Time sensitive',
       level: 'timeSensitive',
     })
   })
@@ -251,7 +251,7 @@ describe('bark query parameters', () => {
     const req = callArgs.request
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
-      body: 'Passive notification',
+      markdown: 'Passive notification',
       level: 'passive',
     })
   })
@@ -269,7 +269,7 @@ describe('bark query parameters', () => {
     const req = callArgs.request
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
-      body: 'Critical alert',
+      markdown: 'Critical alert',
       level: 'critical',
     })
   })
@@ -287,7 +287,7 @@ describe('bark query parameters', () => {
     const req = callArgs.request
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
-      body: 'Loud alert',
+      markdown: 'Loud alert',
       level: 'critical',
       volume: '10',
     })
@@ -306,7 +306,7 @@ describe('bark query parameters', () => {
     const req = callArgs.request
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
-      body: 'Badge count',
+      markdown: 'Badge count',
       badge: 5,
     })
   })
@@ -324,7 +324,7 @@ describe('bark query parameters', () => {
     const req = callArgs.request
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
-      body: 'Auto copy enabled',
+      markdown: 'Auto copy enabled',
       autoCopy: '1',
     })
   })
@@ -342,7 +342,7 @@ describe('bark query parameters', () => {
     const req = callArgs.request
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
-      body: 'Copy text',
+      markdown: 'Copy text',
       copy: 'Text to copy',
     })
   })
@@ -360,7 +360,7 @@ describe('bark query parameters', () => {
     const req = callArgs.request
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
-      body: 'No action on tap',
+      markdown: 'No action on tap',
       action: 'none',
     })
   })
@@ -378,7 +378,7 @@ describe('bark query parameters', () => {
     const req = callArgs.request
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
-      body: 'Archive this',
+      markdown: 'Archive this',
       isArchive: '1',
     })
   })
@@ -396,7 +396,7 @@ describe('bark query parameters', () => {
     const req = callArgs.request
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
-      body: 'Encrypted',
+      markdown: 'Encrypted',
       ciphertext: 'encryptedData123',
     })
   })
@@ -415,7 +415,7 @@ describe('bark query parameters', () => {
     expect(await req.json()).toEqual({
       device_keys: ['myDeviceKey'],
       title: 'Complex notification',
-      body: 'With many options',
+      markdown: 'With many options',
       subtitle: 'Subtitle',
       group: 'alerts',
       sound: 'alarm',

--- a/packages/statocysts/src/services/push/bark/index.ts
+++ b/packages/statocysts/src/services/push/bark/index.ts
@@ -52,7 +52,7 @@ export const bark = defineProvider('bark:', {
       ['Content-Type', 'application/json'],
     ])
 
-    const contentData: { body: string, title?: string } = message.body ? { title: message.title, body: message.body } : { body: message.title }
+    const contentData: { markdown: string, title?: string } = message.body ? { title: message.title, markdown: message.body } : { markdown: message.title }
 
     const body = defu({ device_keys: deviceKeys }, contentData, query)
 

--- a/packages/statocysts/tests/services/bark.spec.ts
+++ b/packages/statocysts/tests/services/bark.spec.ts
@@ -3,29 +3,102 @@ import { bark } from '#/index'
 import { describe, expect, it } from 'vitest'
 
 describe('bark integration test', () => {
-  it.skipIf(process.env.VITE_BARK_TEST_URL === undefined)(
+  const skipCondition = process.env.VITE_BARK_TEST_URL === undefined
+
+  const expectSuccessResponse: FetchOptions = {
+    onResponse: ({ response }) => {
+      expect(response.status).toBe(200)
+      expect(response._data).toEqual(expect.objectContaining({
+        code: 200,
+        message: 'success',
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            device_key: expect.any(String),
+            code: 200,
+          }),
+        ]),
+        timestamp: expect.any(Number),
+      }))
+    },
+  }
+
+  it.skipIf(skipCondition)(
     'should send a simple message to bark',
     async () => {
-      const fetchOptions: FetchOptions = {
-        onResponse: ({ response }) => {
-          expect(response.status).toBe(200)
-          expect(response._data).toEqual(expect.objectContaining({
-            code: 200,
-            message: 'success',
-            data: expect.arrayContaining([
-              expect.objectContaining({
-                device_key: expect.any(String),
-                code: 200,
-              }),
-            ]),
-            timestamp: expect.any(Number),
-          }))
-        },
-      }
       await bark.send(
         process.env.VITE_BARK_TEST_URL!,
         { title: 'Hello, world!' },
-        { fetchOptions },
+        { fetchOptions: expectSuccessResponse },
+      )
+    },
+  )
+
+  it.skipIf(skipCondition)(
+    'should send markdown content with title and body',
+    async () => {
+      await bark.send(
+        process.env.VITE_BARK_TEST_URL!,
+        {
+          title: 'Markdown Test',
+          body: '## Heading\n- Item 1\n- Item 2\n\n**Bold** and *italic* text',
+        },
+        { fetchOptions: expectSuccessResponse },
+      )
+    },
+  )
+
+  it.skipIf(skipCondition)(
+    'should handle special markdown symbols',
+    async () => {
+      await bark.send(
+        process.env.VITE_BARK_TEST_URL!,
+        {
+          title: 'Special Symbols Test',
+          body: '`code` and ```block```\n> quote\n[link](https://example.com)\n![image](https://example.com/img.png)',
+        },
+        { fetchOptions: expectSuccessResponse },
+      )
+    },
+  )
+
+  it.skipIf(skipCondition)(
+    'should handle special characters and punctuation',
+    async () => {
+      await bark.send(
+        process.env.VITE_BARK_TEST_URL!,
+        {
+          title: 'Punctuation & Symbols',
+          body: '!@#$%^&*()_+-=[]{}|;:\'",.<>?/\\~`',
+        },
+        { fetchOptions: expectSuccessResponse },
+      )
+    },
+  )
+
+  it.skipIf(skipCondition)(
+    'should handle unicode and emoji characters',
+    async () => {
+      await bark.send(
+        process.env.VITE_BARK_TEST_URL!,
+        {
+          title: '中文标题 🎉',
+          body: '中文内容测试\n日本語テスト\n한국어 테스트\n🚀 🔥 ✅ ❌ ⚠️',
+        },
+        { fetchOptions: expectSuccessResponse },
+      )
+    },
+  )
+
+  it.skipIf(skipCondition)(
+    'should handle newlines and whitespace',
+    async () => {
+      await bark.send(
+        process.env.VITE_BARK_TEST_URL!,
+        {
+          title: 'Whitespace Test',
+          body: 'Line 1\n\nLine 2\n\n\nLine 3\n\tTabbed\n  Spaced',
+        },
+        { fetchOptions: expectSuccessResponse },
       )
     },
   )


### PR DESCRIPTION
Bark does not render markdown syntax when content is placed in the body parameter. Using the markdown parameter enables automatic markdown rendering in Bark notifications.

Closes #42

<img width="1024" height="796" alt="image" src="https://github.com/user-attachments/assets/c7878336-8c0c-4285-a8bf-8ab6616ef16b" />
