### PR TITLE
feat: add Lark (飞书) webhook provider

### DIFF
--- a/packages/statocysts/src/browser.ts
+++ b/packages/statocysts/src/browser.ts
@@ -1,5 +1,6 @@
 import type { Sender, SenderUrl } from '#/shared'
 import { discord } from '#/services/chat/discord'
+import { lark } from '#/services/chat/lark'
 import { slack } from '#/services/chat/slack'
 import { telegram } from '#/services/chat/telegram'
 import { bark } from '#/services/push/bark'
@@ -8,7 +9,7 @@ import { buildSenderRegistry } from '#/shared'
 import { assert } from '#/utils'
 import { serverChan } from './services/push/server-chan'
 
-export const senderRegistry = buildSenderRegistry([bark, json, serverChan, jsons, slack, telegram, discord])
+export const senderRegistry = buildSenderRegistry([bark, json, serverChan, jsons, slack, telegram, discord, lark])
 
 export function createSender(urls: SenderUrl[]): Sender {
   return senderRegistry(urls)
@@ -26,5 +27,5 @@ export async function send(
   await provider.send(_url.toString(), messageObj)
 }
 
-export { bark, discord, json, slack, telegram }
+export { bark, discord, json, lark, slack, telegram }
 export * from './shared'

--- a/packages/statocysts/src/index.ts
+++ b/packages/statocysts/src/index.ts
@@ -1,5 +1,6 @@
 import type { Sender, SenderUrl } from '#/shared'
 import { discord } from '#/services/chat/discord'
+import { lark } from '#/services/chat/lark'
 import { slack } from '#/services/chat/slack'
 import { telegram } from '#/services/chat/telegram'
 import { bark } from '#/services/push/bark'
@@ -9,7 +10,7 @@ import { buildSenderRegistry } from '#/shared'
 import { assert } from '#/utils'
 import { serverChan } from './services/push/server-chan'
 
-export const senderRegistry = buildSenderRegistry([bark, email, json, jsons, serverChan, slack, telegram, discord])
+export const senderRegistry = buildSenderRegistry([bark, email, json, jsons, serverChan, slack, telegram, discord, lark])
 
 export function createSender(urls: SenderUrl[]): Sender {
   return senderRegistry(urls)
@@ -27,5 +28,5 @@ export async function send(
   await provider.send(_url.toString(), messageObj)
 }
 
-export { bark, discord, email, json, jsons, slack, telegram }
+export { bark, discord, email, json, jsons, lark, slack, telegram }
 export * from './shared'

--- a/packages/statocysts/src/services/chat/lark/index.spec.ts
+++ b/packages/statocysts/src/services/chat/lark/index.spec.ts
@@ -1,0 +1,151 @@
+import { http } from '#/core/transports/http'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { lark } from '.'
+
+vi.mock('#/core/transports/http', () => ({
+  http: {
+    send: vi.fn(),
+  },
+}))
+
+describe('lark', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+  })
+
+  it('should send a text message with title only', async () => {
+    vi.mocked(http.send).mockResolvedValue(undefined)
+
+    await lark.send(
+      'lark://my-token@webhook',
+      { title: 'Hello, world!' },
+    )
+
+    expect(http.send).toHaveBeenCalledTimes(1)
+    const callArgs = vi.mocked(http.send).mock.calls[0][0]
+    const req = callArgs.request
+    expect(req.method).toBe('POST')
+    expect(req.url).toBe('https://open.larksuite.com/open-apis/bot/v2/hook/my-token')
+    expect(req.headers.get('Content-Type')).toBe('application/json')
+    expect(await req.json()).toEqual({
+      msg_type: 'text',
+      content: { text: 'Hello, world!' },
+    })
+  })
+
+  it('should send an interactive card with title and body', async () => {
+    vi.mocked(http.send).mockResolvedValue(undefined)
+
+    await lark.send(
+      'lark://my-token@webhook',
+      { title: 'Alert', body: '**Something happened**' },
+    )
+
+    expect(http.send).toHaveBeenCalledTimes(1)
+    const callArgs = vi.mocked(http.send).mock.calls[0][0]
+    const req = callArgs.request
+    expect(await req.json()).toEqual({
+      msg_type: 'interactive',
+      card: {
+        header: {
+          title: { tag: 'plain_text', content: 'Alert' },
+        },
+        elements: [
+          { tag: 'markdown', content: '**Something happened**' },
+        ],
+      },
+    })
+  })
+
+  it('should include timestamp and sign when secret is provided', async () => {
+    vi.mocked(http.send).mockResolvedValue(undefined)
+    vi.spyOn(Date, 'now').mockReturnValue(1700000000000)
+
+    await lark.send(
+      'lark://my-token:my-secret@webhook',
+      { title: 'Signed message' },
+    )
+
+    expect(http.send).toHaveBeenCalledTimes(1)
+    const callArgs = vi.mocked(http.send).mock.calls[0][0]
+    const req = callArgs.request
+    const body = await req.json()
+    expect(body.msg_type).toBe('text')
+    expect(body.content).toEqual({ text: 'Signed message' })
+    expect(body.timestamp).toBe('1700000000')
+    expect(body.sign).toBeTypeOf('string')
+    expect(body.sign.length).toBeGreaterThan(0)
+  })
+
+  it('should use feishu domain when domain=feishu', async () => {
+    vi.mocked(http.send).mockResolvedValue(undefined)
+
+    await lark.send(
+      'lark://my-token@webhook?domain=feishu',
+      { title: 'Feishu message' },
+    )
+
+    expect(http.send).toHaveBeenCalledTimes(1)
+    const callArgs = vi.mocked(http.send).mock.calls[0][0]
+    const req = callArgs.request
+    expect(req.url).toBe('https://open.feishu.cn/open-apis/bot/v2/hook/my-token')
+  })
+
+  it('should use larksuite domain by default', async () => {
+    vi.mocked(http.send).mockResolvedValue(undefined)
+
+    await lark.send(
+      'lark://my-token@webhook',
+      { title: 'Lark message' },
+    )
+
+    expect(http.send).toHaveBeenCalledTimes(1)
+    const callArgs = vi.mocked(http.send).mock.calls[0][0]
+    const req = callArgs.request
+    expect(req.url).toBe('https://open.larksuite.com/open-apis/bot/v2/hook/my-token')
+  })
+
+  it('should throw an error if token is missing', async () => {
+    await expect(lark.send(
+      'lark://:secret@webhook',
+      { title: 'Hello' },
+    )).rejects.toThrow('Webhook token is required')
+  })
+
+  it('should throw an error for invalid hostname', async () => {
+    await expect(lark.send(
+      'lark://my-token@invalid',
+      { title: 'Hello' },
+    )).rejects.toThrow('Invalid lark URL')
+  })
+
+  it('should pass fetchOptions when provided', async () => {
+    vi.mocked(http.send).mockResolvedValue(undefined)
+
+    await lark.send(
+      'lark://my-token@webhook',
+      { title: 'Hello' },
+      { fetchOptions: { timeout: 5000 } },
+    )
+
+    expect(http.send).toHaveBeenCalledTimes(1)
+    const callArgs = vi.mocked(http.send).mock.calls[0][0]
+    expect(callArgs.fetchOptions).toEqual({ timeout: 5000 })
+  })
+
+  it('should respect custom baseUrl from options', async () => {
+    vi.mocked(http.send).mockResolvedValue(undefined)
+
+    await lark.send(
+      'lark://my-token@webhook',
+      { title: 'Custom' },
+      { baseUrl: 'https://custom.example.com' },
+    )
+
+    expect(http.send).toHaveBeenCalledTimes(1)
+    const callArgs = vi.mocked(http.send).mock.calls[0][0]
+    const req = callArgs.request
+    expect(req.url).toBe('https://custom.example.com/open-apis/bot/v2/hook/my-token')
+  })
+})

--- a/packages/statocysts/src/services/chat/lark/index.ts
+++ b/packages/statocysts/src/services/chat/lark/index.ts
@@ -1,0 +1,90 @@
+import type { FetchOptions } from 'ofetch'
+import { defineProvider } from '#/core/provider'
+import { http } from '#/core/transports/http'
+import { assert } from '#/utils'
+
+interface LarkOptions {
+  baseUrl?: string
+  fetchOptions?: FetchOptions
+}
+
+const FEISHU_BASE_URL = 'https://open.feishu.cn'
+const LARK_BASE_URL = 'https://open.larksuite.com'
+
+async function computeSign(timestamp: string, secret: string): Promise<string> {
+  const key = `${timestamp}\n${secret}`
+  const encoder = new TextEncoder()
+  const cryptoKey = await globalThis.crypto.subtle.importKey(
+    'raw',
+    encoder.encode(key),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const signature = await globalThis.crypto.subtle.sign('HMAC', cryptoKey, new Uint8Array(0))
+  return btoa(String.fromCharCode(...new Uint8Array(signature)))
+}
+
+export const lark = defineProvider('lark:', {
+  transport: http,
+  defaultOptions: {} as LarkOptions,
+  async prepare(ctx, options) {
+    const { url } = ctx
+
+    assert(url.hostname === 'webhook', 'Invalid lark URL')
+    assert(url.username, 'Webhook token is required')
+
+    const token = url.username
+    const secret = url.password || undefined
+    const domain = url.searchParams.get('domain')
+
+    const baseUrl = options.baseUrl
+      ?? (domain === 'feishu' ? FEISHU_BASE_URL : LARK_BASE_URL)
+
+    const requestUrl = new URL(`/open-apis/bot/v2/hook/${token}`, baseUrl)
+
+    let body: Record<string, unknown>
+
+    if (ctx.message.body) {
+      body = {
+        msg_type: 'interactive',
+        card: {
+          header: {
+            title: { tag: 'plain_text', content: ctx.message.title },
+          },
+          elements: [
+            { tag: 'markdown', content: ctx.message.body },
+          ],
+        },
+      }
+    }
+    else {
+      body = {
+        msg_type: 'text',
+        content: { text: ctx.message.title },
+      }
+    }
+
+    if (secret) {
+      const timestamp = Math.floor(Date.now() / 1000).toString()
+      const sign = await computeSign(timestamp, secret)
+      body.timestamp = timestamp
+      body.sign = sign
+    }
+
+    const headers = new Headers([
+      ['Content-Type', 'application/json'],
+    ])
+
+    const request = new Request(requestUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    })
+
+    return {
+      request,
+      fetchOptions: options.fetchOptions,
+    }
+  },
+})

--- a/packages/statocysts/vitest.config.ts
+++ b/packages/statocysts/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     },
   },
   test: {
-    include: ['tests/**/*.spec.ts'],
+    include: ['tests/**/*.spec.ts', 'src/**/*.spec.ts'],
     testTimeout: 30 * 1000,
     typecheck: {
       enabled: true,


### PR DESCRIPTION
## Summary

- Add Lark/Feishu custom bot webhook provider with text and interactive card message support
- Support HMAC-SHA256 signature verification via Web Crypto API for secure webhooks
- Support both international (`open.larksuite.com`) and domestic (`open.feishu.cn`) domains via `?domain=feishu` query parameter
- Register lark in both Node.js and browser entry points

## URL Scheme

```
lark://{token}@webhook                         # International (larksuite.com)
lark://{token}:{secret}@webhook                # With signature verification
lark://{token}@webhook?domain=feishu           # Domestic (feishu.cn)
lark://{token}:{secret}@webhook?domain=feishu  # Domestic + signature
```

## Test plan

- [x] Unit tests for text messages (title only)
- [x] Unit tests for interactive card messages (title + body)
- [x] Unit tests for HMAC-SHA256 signature generation
- [x] Unit tests for feishu domain switching
- [x] Unit tests for error handling (missing token, invalid hostname)
- [x] Unit tests for fetchOptions passthrough and custom baseUrl
- [x] All 199 existing tests still pass
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)