### PR TITLE
fix(telegram): escape Markdown special chars in default mode

### DIFF
--- a/packages/statocysts/src/services/chat/telegram/index.ts
+++ b/packages/statocysts/src/services/chat/telegram/index.ts
@@ -81,9 +81,9 @@ export const telegram = defineProvider('telegram:', {
         bodyFormatted = escapeMarkdown(this.message.body)
       }
       else {
-        // Markdown or default
-        titleFormatted = `*${this.message.title}*`
-        bodyFormatted = this.message.body
+        // Markdown or default - escape special chars to prevent parse errors
+        titleFormatted = `*${escapeMarkdown(this.message.title)}*`
+        bodyFormatted = escapeMarkdown(this.message.body)
       }
 
       text = `${titleFormatted}\n\n${bodyFormatted}`


### PR DESCRIPTION
Fix 400 Bad Request error when message contains unescaped Markdown characters like _, *, `, etc.

The default Markdown mode now properly escapes special characters to prevent parse errors.

Fixes AEtherside/skland-daily-attendance#100