### PR TITLE
refactor: accept Valibot schemas in query parser

### DIFF
--- a/packages/statocysts/src/services/chat/discord/index.ts
+++ b/packages/statocysts/src/services/chat/discord/index.ts
@@ -3,7 +3,7 @@ import defu from 'defu'
 import * as v from 'valibot'
 import { defineProvider } from '#/core/provider'
 import { http } from '#/core/transports/http'
-import { assert, getValidateQuery } from '#/utils'
+import { assert, safeParseQuery } from '#/utils'
 
 interface DiscordOptions {
   fetchOptions?: FetchOptions
@@ -31,7 +31,7 @@ export const discord = defineProvider('discord:', {
     assert(url.username, 'Webhook ID is required')
     assert(url.password, 'Webhook token is required')
 
-    const queryResult = getValidateQuery(url, data => v.safeParse(querySchema, data))
+    const queryResult = safeParseQuery(url, querySchema)
 
     if (!queryResult.success) {
       throw new Error('Invalid discord query')

--- a/packages/statocysts/src/services/chat/telegram/index.ts
+++ b/packages/statocysts/src/services/chat/telegram/index.ts
@@ -2,7 +2,7 @@ import type { FetchOptions } from 'ofetch'
 import * as v from 'valibot'
 import { defineProvider } from '#/core/provider'
 import { http } from '#/core/transports/http'
-import { escapeHtml, escapeMarkdown, getValidateQuery } from '#/utils'
+import { escapeHtml, escapeMarkdown, safeParseQuery } from '#/utils'
 import { assert } from '#/utils/assert'
 
 export const telegramQuerySchema = v.object({
@@ -36,7 +36,7 @@ export const telegram = defineProvider('telegram:', {
     const pathSegments = url.pathname.split('/').filter(Boolean)
     assert(pathSegments.length > 0, 'At least one chat ID is required')
 
-    const queryResult = getValidateQuery(url, data => v.safeParse(telegramQuerySchema, data))
+    const queryResult = safeParseQuery(url, telegramQuerySchema)
 
     if (!queryResult.success) {
       throw new Error('Invalid telegram query')

--- a/packages/statocysts/src/services/push/bark/index.ts
+++ b/packages/statocysts/src/services/push/bark/index.ts
@@ -4,7 +4,7 @@ import { withProtocol } from 'ufo'
 import * as v from 'valibot'
 import { defineProvider } from '#/core/provider'
 import { http } from '#/core/transports/http'
-import { assert, getValidateQuery, withoutPathname } from '#/utils'
+import { assert, safeParseQuery, withoutPathname } from '#/utils'
 
 export interface BarkOptions {
   fetchOptions?: FetchOptions
@@ -39,7 +39,7 @@ export const bark = defineProvider('bark:', {
     const deviceKeys = url.pathname.split('/').filter(Boolean)
     assert(deviceKeys.length > 0, 'At least one device key is required')
 
-    const queryResult = getValidateQuery(url, data => v.safeParse(querySchema, data))
+    const queryResult = safeParseQuery(url, querySchema)
 
     if (!queryResult.success) {
       throw new Error('Invalid Bark query parameters')

--- a/packages/statocysts/src/utils/url.spec.ts
+++ b/packages/statocysts/src/utils/url.spec.ts
@@ -1,120 +1,57 @@
 import * as v from 'valibot'
-import { describe, expect, it } from 'vitest'
-import { getValidateQuery } from './url'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { safeParseQuery } from './url'
 
-describe('getValidateQuery', () => {
-  it('should parse and validate query params with valibot schema', () => {
+describe('safeParseQuery', () => {
+  it('parses query parameters with a Valibot schema', () => {
     const schema = v.object({
       name: v.string(),
-      age: v.pipe(v.unknown(), v.transform(input => Number(input)), v.number()),
+      age: v.pipe(v.unknown(), v.transform(Number), v.number()),
     })
 
-    const url = 'https://example.com?name=John&age=25'
-    const result = getValidateQuery(url, data => v.parse(schema, data))
+    const result = safeParseQuery('https://example.com?name=John&age=25', schema)
 
-    expect(result).toEqual({ name: 'John', age: 25 })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.output).toEqual({ name: 'John', age: 25 })
+      expectTypeOf(result.output).toEqualTypeOf<{ name: string, age: number }>()
+    }
   })
 
-  it('should work with URL object', () => {
-    const schema = v.object({
-      name: v.string(),
-      age: v.pipe(v.unknown(), v.transform(input => Number(input)), v.number()),
-    })
-
-    const url = new URL('https://example.com?name=Jane&age=30')
-    const result = getValidateQuery(url, data => v.parse(schema, data))
-
-    expect(result).toEqual({ name: 'Jane', age: 30 })
-  })
-
-  it('should handle optional fields with valibot', () => {
-    const schema = v.object({
-      name: v.string(),
-      age: v.optional(v.pipe(v.unknown(), v.transform(input => Number(input)), v.number())),
-      email: v.optional(v.pipe(v.string(), v.email())),
-    })
-
-    const url = 'https://example.com?name=Alice'
-    const result = getValidateQuery(url, data => v.parse(schema, data))
-
-    expect(result).toEqual({ name: 'Alice' })
-  })
-
-  it('should handle default values with valibot', () => {
+  it('accepts a URL object and applies schema defaults', () => {
     const schema = v.object({
       name: v.string(),
       role: v.optional(v.string(), 'user'),
-      isActive: v.optional(v.pipe(v.unknown(), v.transform(input => Boolean(input)), v.boolean()), true),
     })
 
-    const url = 'https://example.com?name=Bob'
-    const result = getValidateQuery(url, data => v.parse(schema, data))
+    const result = safeParseQuery(new URL('https://example.com?name=Jane'), schema)
 
-    expect(result).toEqual({ name: 'Bob', role: 'user', isActive: true })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.output).toEqual({ name: 'Jane', role: 'user' })
+    }
   })
 
-  it('should validate array query params', () => {
+  it('preserves repeated query parameters for array schemas', () => {
     const schema = v.object({
       tags: v.array(v.string()),
     })
 
-    const url = 'https://example.com?tags=foo&tags=bar&tags=baz'
-    const result = getValidateQuery(url, data => v.parse(schema, data))
+    const result = safeParseQuery('https://example.com?tags=foo&tags=bar&tags=baz', schema)
 
-    expect(result).toEqual({ tags: ['foo', 'bar', 'baz'] })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.output).toEqual({ tags: ['foo', 'bar', 'baz'] })
+    }
   })
 
-  it('should handle complex nested schemas', () => {
-    const schema = v.object({
-      user: v.string(),
-      settings: v.optional(v.object({
-        theme: v.optional(v.picklist(['light', 'dark']), 'light'),
-        notifications: v.optional(v.pipe(v.unknown(), v.transform(input => Boolean(input)), v.boolean()), true),
-      }), { theme: 'light', notifications: true }),
-    })
-
-    const url = 'https://example.com?user=admin'
-    const result = getValidateQuery(url, data => v.parse(schema, data))
-
-    expect(result).toEqual({
-      user: 'admin',
-      settings: { theme: 'light', notifications: true },
-    })
-  })
-
-  it('should throw validation error for invalid data', () => {
-    const schema = v.object({
-      age: v.pipe(v.unknown(), v.transform(input => Number(input)), v.number(), v.minValue(18)),
-    })
-
-    const url = 'https://example.com?age=15'
-
-    expect(() => {
-      getValidateQuery(url, data => v.parse(schema, data))
-    }).toThrow()
-  })
-
-  it('should throw error for missing required fields', () => {
-    const schema = v.object({
-      name: v.string(),
-      email: v.pipe(v.string(), v.email()),
-    })
-
-    const url = 'https://example.com?name=John'
-
-    expect(() => {
-      getValidateQuery(url, data => v.parse(schema, data))
-    }).toThrow()
-  })
-
-  it('should handle safeParse for graceful error handling', () => {
+  it('returns validation issues instead of throwing', () => {
     const schema = v.object({
       email: v.pipe(v.string(), v.email()),
-      age: v.pipe(v.unknown(), v.transform(input => Number(input)), v.number(), v.minValue(0), v.maxValue(150)),
+      age: v.pipe(v.unknown(), v.transform(Number), v.number(), v.maxValue(150)),
     })
 
-    const url = 'https://example.com?email=invalid&age=200'
-    const result = getValidateQuery(url, data => v.safeParse(schema, data))
+    const result = safeParseQuery('https://example.com?email=invalid&age=200', schema)
 
     expect(result.success).toBe(false)
     if (!result.success) {
@@ -122,126 +59,14 @@ describe('getValidateQuery', () => {
     }
   })
 
-  it('should work with custom parser function', () => {
-    const customParser = (data: unknown) => {
-      const params = data as Record<string, string>
-      return {
-        fullName: `${params.firstName} ${params.lastName}`,
-        isAdmin: params.admin === 'true',
-      }
-    }
-
-    const url = 'https://example.com?firstName=John&lastName=Doe&admin=true'
-    const result = getValidateQuery(url, customParser)
-
-    expect(result).toEqual({
-      fullName: 'John Doe',
-      isAdmin: true,
-    })
-  })
-
-  it('should handle empty query params', () => {
-    const schema = v.looseObject({})
-
-    const url = 'https://example.com'
-    const result = getValidateQuery(url, data => v.parse(schema, data))
-
-    expect(result).toEqual({})
-  })
-
-  it('should handle number coercion', () => {
+  it('reports missing required query parameters', () => {
     const schema = v.object({
-      page: v.pipe(v.unknown(), v.transform(input => Number(input)), v.number(), v.integer(), v.gtValue(0)),
-      limit: v.pipe(v.unknown(), v.transform(input => Number(input)), v.number(), v.integer(), v.gtValue(0), v.maxValue(100)),
-      price: v.pipe(v.unknown(), v.transform(input => Number(input)), v.number()),
+      name: v.string(),
+      email: v.pipe(v.string(), v.email()),
     })
 
-    const url = 'https://example.com?page=2&limit=50&price=99.99'
-    const result = getValidateQuery(url, data => v.parse(schema, data))
+    const result = safeParseQuery('https://example.com?name=John', schema)
 
-    expect(result).toEqual({ page: 2, limit: 50, price: 99.99 })
-  })
-
-  it('should handle boolean coercion', () => {
-    const schema = v.object({
-      isActive: v.pipe(v.unknown(), v.transform(input => Boolean(input)), v.boolean()),
-      hasAccess: v.pipe(v.unknown(), v.transform(input => Boolean(input)), v.boolean()),
-    })
-
-    const url = 'https://example.com?isActive=true&hasAccess=1'
-    const result = getValidateQuery(url, data => v.parse(schema, data))
-
-    expect(result).toEqual({ isActive: true, hasAccess: true })
-  })
-
-  it('should handle enum validation', () => {
-    const schema = v.object({
-      status: v.picklist(['active', 'inactive', 'pending']),
-      priority: v.picklist(['low', 'medium', 'high']),
-    })
-
-    const url = 'https://example.com?status=active&priority=high'
-    const result = getValidateQuery(url, data => v.parse(schema, data))
-
-    expect(result).toEqual({ status: 'active', priority: 'high' })
-  })
-
-  it('should throw error for invalid enum value', () => {
-    const schema = v.object({
-      status: v.picklist(['active', 'inactive']),
-    })
-
-    const url = 'https://example.com?status=unknown'
-
-    expect(() => {
-      getValidateQuery(url, data => v.parse(schema, data))
-    }).toThrow()
-  })
-
-  it('should transform data after validation', () => {
-    const schema = v.object({
-      date: v.pipe(v.string(), v.transform(val => new Date(val))),
-      amount: v.pipe(v.unknown(), v.transform(input => Number(input)), v.number(), v.transform(val => val * 100)),
-    })
-
-    const url = 'https://example.com?date=2023-01-01&amount=10.5'
-    const result = getValidateQuery(url, data => v.parse(schema, data))
-
-    expect(result.date).toBeInstanceOf(Date)
-    expect(result.amount).toBe(1050)
-  })
-
-  it('should work with valibot check for custom validation', () => {
-    const schema = v.pipe(
-      v.object({
-        password: v.pipe(v.string(), v.minLength(8)),
-        confirmPassword: v.string(),
-      }),
-      v.check(data => data.password === data.confirmPassword, 'Passwords do not match'),
-    )
-
-    const url = 'https://example.com?password=secret123&confirmPassword=secret123'
-    const result = getValidateQuery(url, data => v.parse(schema, data))
-
-    expect(result).toEqual({
-      password: 'secret123',
-      confirmPassword: 'secret123',
-    })
-  })
-
-  it('should throw error when check validation fails', () => {
-    const schema = v.pipe(
-      v.object({
-        password: v.string(),
-        confirmPassword: v.string(),
-      }),
-      v.check(data => data.password === data.confirmPassword),
-    )
-
-    const url = 'https://example.com?password=pass1&confirmPassword=pass2'
-
-    expect(() => {
-      getValidateQuery(url, data => v.parse(schema, data))
-    }).toThrow()
+    expect(result.success).toBe(false)
   })
 })

--- a/packages/statocysts/src/utils/url.ts
+++ b/packages/statocysts/src/utils/url.ts
@@ -1,11 +1,11 @@
 import { getQuery } from 'ufo'
+import * as v from 'valibot'
 
-export function getValidateQuery<T>(
+export function safeParseQuery<const TSchema extends v.GenericSchema>(
   url: URL | string,
-  parser: (params: unknown) => T,
-): T {
-  const query = getQuery(url.toString())
-  return parser(query)
+  schema: TSchema,
+): v.SafeParseResult<TSchema> {
+  return v.safeParse(schema, getQuery(url.toString()))
 }
 
 export function withoutPathname(input: string): string {


### PR DESCRIPTION
## Summary

Stacked on #85.

Refactor the query parsing utility to accept a Valibot schema directly instead of an arbitrary parser callback.

## Changes

- Rename `getValidateQuery()` to `safeParseQuery()`
- Accept `v.GenericSchema` as the second argument
- Preserve exact schema output inference via `v.SafeParseResult<TSchema>`
- Centralize `v.safeParse()` inside the utility
- Update Bark, Discord, and Telegram call sites
- Focus `url.spec.ts` on URL query extraction, schema delegation, type inference, repeated parameters, and validation failures instead of retesting Valibot's full API

Before:

```ts
getValidateQuery(url, data => v.safeParse(querySchema, data))
```

After:

```ts
safeParseQuery(url, querySchema)
```

## Rationale

All production call sites introduced by #85 use the same Valibot `safeParse` adapter. Accepting a schema narrows the interface to its actual purpose, removes repeated callback wrappers, and keeps provider-specific error handling intact.

This is an interface-quality refactor, not an additional bundle-size optimization.

## Test Plan

- `pnpm test`: 208 passed (202 statocysts + 6 CLI), 25 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
